### PR TITLE
Move #include <algorithm>

### DIFF
--- a/include/clara.h
+++ b/include/clara.h
@@ -40,6 +40,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <algorithm>
 
 // Use optional outer namespace
 #ifdef STITCH_TBC_TEXT_FORMAT_OUTER_NAMESPACE
@@ -180,7 +181,6 @@ namespace Tbc {
 
 
 #include <map>
-#include <algorithm>
 #include <stdexcept>
 #include <memory>
 

--- a/srcs/tbc_text_format.h
+++ b/srcs/tbc_text_format.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <algorithm>
 
 // Use optional outer namespace
 #ifdef STITCH_TBC_TEXT_FORMAT_OUTER_NAMESPACE


### PR DESCRIPTION
algorithm is needed in tbc_text_format.h (for std::min)

The following minimal example failed to compile (VS2013 update 5):

```c++
#define CLARA_CONFIG_MAIN
#include <clara.h>

int main(int argc, char* argv[])
{
    return 0;
}

```