### PR TITLE
Fix VS2015 warning C4702: unreachable code.

### DIFF
--- a/include/clara.h
+++ b/include/clara.h
@@ -221,6 +221,9 @@ namespace Clara {
         template<typename T>    struct IsBool       { static const bool value = false; };
         template<>              struct IsBool<bool> { static const bool value = true; };
 
+        // This is just to avoid compiler warnings (e.g. unreachable code).
+        inline bool isTrue( bool value ) { return value; }
+
         template<typename T>
         void convertInto( std::string const& _source, T& _dest ) {
             std::stringstream ss;
@@ -247,7 +250,8 @@ namespace Clara {
         }
         template<typename T>
         inline void convertInto( bool, T& ) {
-            throw std::runtime_error( "Invalid conversion" );
+            if (isTrue(true))
+                throw std::runtime_error( "Invalid conversion" );
         }
 
         template<typename ConfigT>

--- a/include/clara.h
+++ b/include/clara.h
@@ -373,18 +373,11 @@ namespace Clara {
                 convertInto( stringValue, value );
                 function( obj, value );
             }
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4702) // unreachable code (lines following convertInto(bool, T&) invocation)
-#endif
             virtual void setFlag( C& obj ) const {
                 typename RemoveConstRef<T>::type value;
                 convertInto( true, value );
                 function( obj, value );
             }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
             virtual bool takesArg() const { return !IsBool<T>::value; }
             virtual IArgFunction<C>* clone() const { return new BoundBinaryFunction( *this ); }
             void (*function)( C&, T );

--- a/include/clara.h
+++ b/include/clara.h
@@ -369,11 +369,18 @@ namespace Clara {
                 convertInto( stringValue, value );
                 function( obj, value );
             }
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4702) // unreachable code (lines following convertInto(bool, T&) invocation)
+#endif
             virtual void setFlag( C& obj ) const {
                 typename RemoveConstRef<T>::type value;
                 convertInto( true, value );
                 function( obj, value );
             }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
             virtual bool takesArg() const { return !IsBool<T>::value; }
             virtual IArgFunction<C>* clone() const { return new BoundBinaryFunction( *this ); }
             void (*function)( C&, T );


### PR DESCRIPTION
This clears `warning C4702: unreachable code` reported while building Clara-based project (e.g. Catch), in **Release** configuration, using VS2015 Update 1 with warning level `/W4`.

Apparently, `convertInto` invocation resolves to call the always throwing variant:
```
        template<typename T>
        inline void convertInto( bool, T& ) {
            throw std::runtime_error( "Invalid conversion" );
        }
```

The issue has been discovered while switching nanodbc project to Catch (lexicalunit/nanodbc#90).