### PR TITLE
Add missing "const" to parseInto()

### DIFF
--- a/include/clara.h
+++ b/include/clara.h
@@ -900,7 +900,7 @@ namespace Clara {
             return config;
         }
 
-        std::vector<Parser::Token> parseInto( int argc, char const* argv[], ConfigT& config ) const {
+        std::vector<Parser::Token> parseInto( int argc, char const* const argv[], ConfigT& config ) const {
             std::string processName = argv[0];
             std::size_t lastSlash = processName.find_last_of( "/\\" );
             if( lastSlash != std::string::npos )

--- a/projects/tests/tests.cpp
+++ b/projects/tests/tests.cpp
@@ -116,7 +116,12 @@ TEST_CASE( "cmdline" ) {
 
         CHECK( config.number == 0 );
     }
-    
+
+    SECTION( "parse" ) {
+        const char* argv[] = { "test" };
+        const TestOpt other = cli.parse(1, argv);
+    }
+
     SECTION( "two parsers" ) {
 
         TestOpt config1;

--- a/srcs/clara.h
+++ b/srcs/clara.h
@@ -590,7 +590,7 @@ namespace Clara {
             return config;
         }
 
-        std::vector<Parser::Token> parseInto( int argc, char const* argv[], ConfigT& config ) const {
+        std::vector<Parser::Token> parseInto( int argc, char const* const argv[], ConfigT& config ) const {
             std::string processName = argv[0];
             std::size_t lastSlash = processName.find_last_of( "/\\" );
             if( lastSlash != std::string::npos )


### PR DESCRIPTION
Without it, the call to it from parse() didn't compile because array of const
pointers is not convertible to an array of non-const ones.

Add a test case verifying that parse() at least compiles and regenerate
clara.h to actually make it pass.