### PR TITLE
Use COLUMNS environment variable for console width

### DIFF
--- a/projects/tests/catch.hpp
+++ b/projects/tests/catch.hpp
@@ -3048,17 +3048,36 @@ namespace STITCH_TBC_TEXT_FORMAT_OUTER_NAMESPACE {
 
 namespace Tbc {
 
-#ifdef TBC_TEXT_FORMAT_CONSOLE_WIDTH
-    const unsigned int consoleWidth = TBC_TEXT_FORMAT_CONSOLE_WIDTH;
-#else
-    const unsigned int consoleWidth = 80;
-#endif
-
     struct TextAttributes {
+        static std::size_t getDefaultWidth() {
+#ifdef TBC_TEXT_FORMAT_CONSOLE_WIDTH
+            return TBC_TEXT_FORMAT_CONSOLE_WIDTH;
+#else
+            static std::size_t width = 0;
+
+            if( !width ) {
+                // Determining the real console width is not trivial as it
+                // needs to be done in different ways for different platforms,
+                // so we rely on the standard environment variable instead.
+                if( char const* const colstr = std::getenv("COLUMNS") ) {
+                    int const colnum = std::atoi(colstr);
+                    if( colnum > 0 )
+                        width = static_cast<std::size_t>(colnum);
+                }
+
+                // Fall back to the hard-coded default.
+                if( !width )
+                    width = 80;
+            }
+
+            return width;
+#endif
+        }
+
         TextAttributes()
         :   initialIndent( std::string::npos ),
             indent( 0 ),
-            width( consoleWidth-1 ),
+            width( getDefaultWidth()-1 ),
             tabChar( '\t' )
         {}
 

--- a/srcs/clara.h
+++ b/srcs/clara.h
@@ -50,12 +50,6 @@ namespace Clara {
 
     namespace Detail {
 
-#ifdef CLARA_CONSOLE_WIDTH
-    const unsigned int consoleWidth = CLARA_CONFIG_CONSOLE_WIDTH;
-#else
-    const unsigned int consoleWidth = 80;
-#endif
-
         // Use this to try and stop compiler from warning about unreachable code
         inline bool isTrue( bool value ) { return value; }
         
@@ -513,7 +507,10 @@ namespace Clara {
             m_boundProcessName = new Detail::BoundUnaryMethod<C,M>( _unaryMethod );
         }
 
-        void optUsage( std::ostream& os, std::size_t indent = 0, std::size_t width = Detail::consoleWidth ) const {
+        void optUsage( std::ostream& os, std::size_t indent = 0, std::size_t width = 0 ) const {
+            if( !width )
+                width = Detail::TextAttributes::getDefaultWidth();
+
             typename std::vector<Arg>::const_iterator itBegin = m_options.begin(), itEnd = m_options.end(), it;
             std::size_t maxWidth = 0;
             for( it = itBegin; it != itEnd; ++it )

--- a/srcs/tbc_text_format.h
+++ b/srcs/tbc_text_format.h
@@ -11,6 +11,7 @@
 #define TBC_TEXT_FORMAT_H_INCLUDED
 #endif
 
+#include <cstdlib>
 #include <string>
 #include <vector>
 #include <sstream>
@@ -23,17 +24,36 @@ namespace STITCH_TBC_TEXT_FORMAT_OUTER_NAMESPACE {
 
 namespace Tbc {
 
-#ifdef TBC_TEXT_FORMAT_CONSOLE_WIDTH
-    const unsigned int consoleWidth = TBC_TEXT_FORMAT_CONSOLE_WIDTH;
-#else
-    const unsigned int consoleWidth = 80;
-#endif
-
     struct TextAttributes {
+        static std::size_t getDefaultWidth() {
+#ifdef TBC_TEXT_FORMAT_CONSOLE_WIDTH
+            return TBC_TEXT_FORMAT_CONSOLE_WIDTH;
+#else
+            static std::size_t width = 0;
+
+            if( !width ) {
+                // Determining the real console width is not trivial as it
+                // needs to be done in different ways for different platforms,
+                // so we rely on the standard environment variable instead.
+                if( char const* const colstr = std::getenv("COLUMNS") ) {
+                    int const colnum = std::atoi(colstr);
+                    if( colnum > 0 )
+                        width = static_cast<std::size_t>(colnum);
+                }
+
+                // Fall back to the hard-coded default.
+                if( !width )
+                    width = 80;
+            }
+
+            return width;
+#endif
+        }
+
         TextAttributes()
         :   initialIndent( std::string::npos ),
             indent( 0 ),
-            width( consoleWidth-1 ),
+            width( getDefaultWidth()-1 ),
             tabChar( '\t' )
         {}
 


### PR DESCRIPTION
If this variable is defined (which is not always the case but at least
respecting it allows us to wrap things properly if it is), use it instead of
the hard-coded 80 character line width.

Closes #7.

----
Notice that I had to update `catch.hpp` as well because otherwise I was getting incomprehensible errors from `main.cpp` which used `Tbc::TextAttributes` from there and not from `clara.h` itself. In fact, I think this points out a serious problem with the current stitching approach: it can easily result in ODR violations because the same stuff is stitched into both `catch.hpp` and `clara.h`. To solve this you'd need to use unique namespaces for the internal stuff for the two headers.

BTW, why does Clara use `.h` extension when CATCH uses `.hpp`? Wouldn't it be better to use the latter for Clara too, if only for consistency?